### PR TITLE
chore: alter cli names and add timeout for e2e test

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -7,19 +7,19 @@ export default function cli(cliMeta) {
         const parser = new ArgumentParser(cliMeta);
 
         parser.addArgument(['-b', '--blockSize'], {
-            help: 'anticipated CIDR block size'
+            help: 'The anticipated CIDR block size'
         });
         parser.addArgument(['-s', '--rangeStart'], {
-            help: 'range start'
+            help: 'The start of the desired range for the new CIDR block'
         });
         parser.addArgument(['-e', '--rangeEnd'], {
-            help: 'range end'
+            help: 'The end of the desired range for the new CIDR block'
         });
-        parser.addArgument(['-t', '--routeTableTagName'], {
-            help: 'route table tag name'
+        parser.addArgument(['-n', '--routeTableTagName'], {
+            help: 'The tag name for the route table(s)'
         });
-        parser.addArgument(['-z', '--routeTableTagValue'], {
-            help: 'route table tag value'
+        parser.addArgument(['-x', '--routeTableTagValue'], {
+            help: 'The tag value for the route table(s)'
         });
 
         resolve(validateArguments(parser.parseArgs()));

--- a/src/index.e2e.test.js
+++ b/src/index.e2e.test.js
@@ -5,9 +5,10 @@ const exec = util.promisify(require('child_process').exec);
 describe('index e2e tests', function () {
 
     this.slow(5000);
+    this.timeout(5000);
 
     it('should generate a free CIDR block', async () => {
-        const command = 'node ./lib/index.js -b 24 -s 10.180.0.0 -e 10.200.0.0 -t FAKE-TAG-NAME -z FAKE-TAG-VALUE';
+        const command = 'node ./lib/index.js -b 24 -s 10.180.0.0 -e 10.200.0.0 -n FAKE-TAG-NAME -x FAKE-TAG-VALUE';
 
         const { stdout } = await exec(command);
 

--- a/src/index.e2e.test.js
+++ b/src/index.e2e.test.js
@@ -5,7 +5,7 @@ const exec = util.promisify(require('child_process').exec);
 describe('index e2e tests', function () {
 
     this.slow(5000);
-    this.timeout(5000);
+    this.timeout(10000);
 
     it('should generate a free CIDR block', async () => {
         const command = 'node ./lib/index.js -b 24 -s 10.180.0.0 -e 10.200.0.0 -n FAKE-TAG-NAME -x FAKE-TAG-VALUE';


### PR DESCRIPTION
I had to add a timeout of 5000ms to the e2e test as they were failing for me with:

Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

They seem to take 3 and a bit seconds each.

Should this be included so it passes on slow machines like mine?